### PR TITLE
add bin to package

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 require('dotenv-expand')(require('dotenv').config())
 const fs = require('fs')
 const _path = require('path');

--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
     "form-urlencoded": "^6.0.0",
     "node-fetch": "^2.6.0",
     "string.prototype.matchall": "^4.0.2"
+  },
+  "bin": {
+    "tailwindui-crawler": "./index.js"
   }
 }


### PR DESCRIPTION
[ possibly unwanted change ]

A workflow that I have been using is to include crawler in my project and download files under vendor folder but currently to do that we have to go run index file from node_modules, solving this by adding bin for this package so we can directly call it.

( wanted to leave a disclaimer on top cause this change might not be how the maintainers want people to use this lib )