### PR TITLE
fix TypeError: reject.err is not a function

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -105,7 +105,7 @@ async function fetchHttps(url, options = {}, body = undefined) {
     })
 
     req.on('error', (error) => {
-      reject.err(error)
+      reject(error)
     })
     if (body) {
       req.write(body)


### PR DESCRIPTION
When I ran the crawler it failed due to a Type Error. I later found that due to my VPN the remote was resetting my connection after each request resulting in hitting `req.on('error', (error)`, but as in the snippet below it resulted in a Type Error. The simple change in this PR fixes the Type Error.

```
tailwindui-crawler/index.mjs:108
      reject.err(error)
             ^
TypeError: reject.err is not a function
```

I replaced the reject.err with a console log to find out myself why it failed, result:
```
Error: read ECONNRESET
    at TLSWrap.onStreamRead (node:internal/stream_base_commons:217:20) {
  errno: -54,
  code: 'ECONNRESET',
  syscall: 'read'
}
```