### PR TITLE
Fix crawler skipping downloading components

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -240,7 +240,10 @@ function replaceTokens(html) {
 async function processComponent(url, component) {
   const title = component.name
   const filename = cleanFilename(title)
-  const path = `${url}/${filename}`
+
+  // Remove the rootUrl from the url to get the local path
+  const localOutput = url.replace('https://tailwindui.com', '')
+  const path = `${localOutput}/${filename}`
 
   // output snippets by language
   component.snippets.forEach((snippet) => {
@@ -439,7 +442,9 @@ function debugLog(...args) {
       debugLog(`📣   ${i + 1}: ${url}`)
       if (!url || !url.match(/\/components\//)) continue
       // check if component is in list of components to save
-      const component = url.split('/')[2]
+      // Example URL: https://tailwindui.com/components/application-ui/navigation/navbars
+      // Parse out "application-ui" | "marketing" | "ecommerce" from the URL to ensure we only download the components we want
+      const component = url.split('/')[4]
       if (
         component &&
         components[0] !== 'all' &&


### PR DESCRIPTION
Fixes #86 

There are a couple of issues here
1. The path is currently derived from the URL, which means that we get incorrect downstream paths like `./output/components/htmlhttps://tailwindui.com/components/application-ui/navigation/navbars` when passing this `path` const.
2. The downloader is skipping components because it's not parsing the correct segment of the URL. `[4]` instead of `[2]` here is what we need to parse the correct segment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved accuracy in local path generation based on component URLs.
	- Enhanced component identification from URLs for better filtering.

- **Bug Fixes**
	- Corrected the extraction of component names from URLs to align with the intended structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->